### PR TITLE
Remove failing tests thanks to new MOI release

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -169,7 +169,7 @@ function MOI.add_constrained_variables(model::Optimizer, set::SupportedSets)
             length(model.blksz),
             model.Ainfo_entptr[i],
             model.Ainfo_type[i],
-            _prev(model, i),
+            _next(model, i),
         )
     end
     _fill_until(
@@ -201,14 +201,13 @@ function _isless(t1::MOI.VectorAffineTerm, t2::MOI.VectorAffineTerm)
     end
 end
 
-function _prev(model::Optimizer, i)
-    prev = 0
-    for j in i:-1:1
+function _next(model::Optimizer, i)
+    for j in (i+1):length(model.Ainfo_entptr)
         if !isempty(model.Ainfo_entptr[j])
-            prev = last(model.Ainfo_entptr[j])
+            return first(model.Ainfo_entptr[j])
         end
     end
-    return prev
+    return length(model.Aent)
 end
 
 function _fill_until(
@@ -332,7 +331,7 @@ function MOI.optimize!(model::Optimizer)
         CAcol,
         CAinfo_entptr,
         CAinfo_type,
-        params = model.params,
+        params = params,
         maxranks = model.maxranks,
         ranks = model.ranks,
         R = model.R,

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -16,6 +16,7 @@ function test_runtests()
         Float64,
     )
     config = MOI.Test.Config(
+        rtol = 1e-1,
         atol = 1e-1,
         exclude = Any[
             MOI.ConstraintBasisStatus,
@@ -31,30 +32,14 @@ function test_runtests()
         model,
         config,
         exclude = [
-            # Needs https://github.com/jump-dev/MathOptInterface.jl/pull/2358
-            r"test_basic_VectorOfVariables_Nonpositives$",
-            # Needs https://github.com/jump-dev/MathOptInterface.jl/pull/2360
-            r"test_basic_VectorOfVariables_SecondOrderCone$",
-            # Needs https://github.com/jump-dev/MathOptInterface.jl/pull/2359
-            r"test_constraint_PrimalStart_DualStart_SecondOrderCone$",
-            # Needs https://github.com/jump-dev/MathOptInterface.jl/pull/2357
-            r"test_model_ListOfVariablesWithAttributeSet$",
-            r"test_model_LowerBoundAlreadySet$",
-            r"test_model_UpperBoundAlreadySet$",
-            r"test_model_ScalarFunctionConstantNotZero$",
-            r"test_model_delete$",
             # Detecting infeasibility or unboundedness not supported
             "INFEAS",
-            "infeasible",
-            # Incorrect `ConstraintDual` for `vc2` for MacOS in CI
-            r"test_linear_integration",
-            # FIXME investigate
-            r"test_conic_SecondOrderCone_nonnegative_post_bound$",
+            # These three are unbounded even if it's not in the name
             r"test_conic_SecondOrderCone_negative_post_bound_2$",
             r"test_conic_SecondOrderCone_negative_post_bound_3$",
             r"test_conic_SecondOrderCone_no_initial_bound$",
-            r"test_linear_add_constraints$",
-            r"test_modification_affine_deletion_edge_cases$",
+            # Incorrect `ConstraintDual` for `vc2` for MacOS in CI
+            r"test_linear_integration$",
         ],
     )
     return


### PR DESCRIPTION
Thanks to https://github.com/jump-dev/MathOptInterface.jl/pull/2357, a lot of failing tests are now passing. This highlighted `test_modification_affine_deletion_edge_cases` which actually was a bug in this MOI wrapper which is fixed by this PR.

The only remaining failing tests are unbounded/infeasible tests which is expected + one numerical failure on MacOS :tada: 